### PR TITLE
Implement getInputSources

### DIFF
--- a/src/api/XRInputPose.js
+++ b/src/api/XRInputPose.js
@@ -17,9 +17,6 @@ import { mat4_identity } from '../math';
 
 const PRIVATE = Symbol('@@webxr-polyfill/XRInputPose');
 
-const XRHandednessList = ['', 'left', 'right'];
-const XRPointerOriginList = ['head', 'hand', 'screen'];
-
 export default class XRInputPose {
   /**
    * @param {boolean} emulatedPosition

--- a/src/api/XRInputPose.js
+++ b/src/api/XRInputPose.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mat4_identity } from '../math';
+
+const PRIVATE = Symbol('@@webxr-polyfill/XRInputPose');
+
+const XRHandednessList = ['', 'left', 'right'];
+const XRPointerOriginList = ['head', 'hand', 'screen'];
+
+export default class XRInputPose {
+  /**
+   * @param {boolean} emulatedPosition
+   * @param {Float32Array} pointerMatrix
+   * @param {Float32Array} gripMatrix
+   */
+  constructor(inputSourceImpl, hasGripMatrix) {
+    this[PRIVATE] = {
+      inputSourceImpl,
+      pointerMatrix: mat4_identity(new Float32Array(16)),
+      gripMatrix: hasGripMatrix ? mat4_identity(new Float32Array(16)) : null,
+    };
+  }
+
+  /**
+   * @return {boolean}
+   */
+  get emulatedPosition() { return this[PRIVATE].inputSourceImpl.emulatedPosition; }
+
+  /**
+   * @return {Float32Array}
+   */
+  get pointerMatrix() { return this[PRIVATE].pointerMatrix; }
+
+  /**
+   * @return {Float32Array}
+   */
+  get gripMatrix() { return this[PRIVATE].gripMatrix; }
+}

--- a/src/api/XRInputSource.js
+++ b/src/api/XRInputSource.js
@@ -30,6 +30,7 @@ export class XRInputSourceImpl {
     this.emulatedPosition = false;
     this.basePoseMatrix = mat4_identity(new Float32Array(16));
     this.inputPoses = new WeakMap(); // Map of XRCoordinateSystem:XRInputPose
+    this.primaryActionPressed = false;
   }
 
   updateFromGamepad(gamepad) {

--- a/src/api/XRInputSource.js
+++ b/src/api/XRInputSource.js
@@ -13,91 +13,9 @@
  * limitations under the License.
  */
 
-import XRInputPose from './XRInputPose';
-import { mat4_identity, mat4_fromRotationTranslation, mat4_copy } from '../math';
-
 const PRIVATE = Symbol('@@webxr-polyfill/XRInputSource');
 
-const HEAD_CONTROLLER_RIGHT_OFFSET = new Float32Array([0.155, -0.465, -0.35]);
-const HEAD_CONTROLLER_LEFT_OFFSET = new Float32Array([-0.155, -0.465, -0.35]);
-
-export class XRInputSourceImpl {
-  constructor(polyfill, primaryButtonIndex = 0) {
-    this.polyfill = polyfill;
-    this.gamepad = null;
-    this.inputSource = new XRInputSource(this);
-    this.lastPosition = new Float32Array(3);
-    this.emulatedPosition = false;
-    this.basePoseMatrix = mat4_identity(new Float32Array(16));
-    this.inputPoses = new WeakMap(); // Map of XRCoordinateSystem:XRInputPose
-    this.primaryButtonIndex = primaryButtonIndex;
-    this.primaryActionPressed = false;
-  }
-
-  updateFromGamepad(gamepad) {
-    this.gamepad = gamepad;
-    this.inputSource[PRIVATE].handedness = gamepad.hand;
-
-    if (gamepad.pose) {
-      this.inputSource[PRIVATE].pointerOrigin = 'hand';
-      this.emulatedPosition = !gamepad.pose.hasPosition;
-    } else if (gamepad.hand === '') {
-      this.inputSource[PRIVATE].pointerOrigin = 'head';
-      this.emulatedPosition = false;
-    }
-  }
-
-  updateBasePoseMatrix() {
-    if (this.gamepad && this.gamepad.pose) {
-      let pose = this.gamepad.pose;
-      let position = pose.position;
-      let orientation = pose.orientation;
-      // On initialization, we might not have any values
-      if (!position && !orientation) {
-        return;
-      }
-      if (!position) {
-        if (!pose.hasPosition) {
-          // TODO: Should do an elbow model here.
-          if (this.gamepad.hand == 'left') {
-            position = HEAD_CONTROLLER_LEFT_OFFSET;
-          } else {
-            position = HEAD_CONTROLLER_RIGHT_OFFSET;
-          }
-        } else {
-          position = this.lastPosition;
-        }
-      } else {
-        // This is if we temporarily lose tracking, so the controller doesn't
-        // snap back to the origin.
-        this.lastPosition[0] = position[0];
-        this.lastPosition[1] = position[1];
-        this.lastPosition[2] = position[2];
-      }
-      mat4_fromRotationTranslation(this.basePoseMatrix, orientation, position);
-    } else {
-      mat4_copy(this.basePoseMatrix, this.polyfill.getBasePoseMatrix());
-    }
-    return this.basePoseMatrix;
-  }
-
-  getXRInputPose(coordinateSystem) {
-    this.updateBasePoseMatrix();
-    let inputPose = this.inputPoses.get(coordinateSystem);
-    if (!inputPose) {
-      inputPose = new XRInputPose(this, this.gamepad && this.gamepad.pose);
-      this.inputPoses.set(coordinateSystem, inputPose);
-    }
-    // TODO: The pointer matrix should probably be tweaked a bit.
-    coordinateSystem.transformBasePoseMatrix(inputPose.pointerMatrix, this.basePoseMatrix);
-    if (inputPose.gripMatrix) {
-      coordinateSystem.transformBasePoseMatrix(inputPose.gripMatrix, this.basePoseMatrix);
-    }
-    return inputPose;
-  }
-}
-
-export class XRInputSource {
+export default class XRInputSource {
   /**
    * @param {XRHandedness} handedness
    * @param {XRPointerOrigin} pointerOrigin
@@ -105,19 +23,17 @@ export class XRInputSource {
    */
   constructor(impl) {
     this[PRIVATE] = {
-      impl,
-      handedness: '',
-      pointerOrigin: 'head'
+      impl
     };
   }
 
   /**
    * @return {XRHandedness}
    */
-  get handedness() { return this[PRIVATE].handedness; }
+  get handedness() { return this[PRIVATE].impl.handedness; }
 
   /**
    * @return {XRPointerOrigin}
    */
-  get pointerOrigin() { return this[PRIVATE].pointerOrigin; }
+  get pointerOrigin() { return this[PRIVATE].impl.pointerOrigin; }
 }

--- a/src/api/XRInputSource.js
+++ b/src/api/XRInputSource.js
@@ -22,7 +22,7 @@ const HEAD_CONTROLLER_RIGHT_OFFSET = new Float32Array([0.155, -0.465, -0.35]);
 const HEAD_CONTROLLER_LEFT_OFFSET = new Float32Array([-0.155, -0.465, -0.35]);
 
 export class XRInputSourceImpl {
-  constructor(polyfill) {
+  constructor(polyfill, primaryButtonIndex = 0) {
     this.polyfill = polyfill;
     this.gamepad = null;
     this.inputSource = new XRInputSource(this);
@@ -30,6 +30,7 @@ export class XRInputSourceImpl {
     this.emulatedPosition = false;
     this.basePoseMatrix = mat4_identity(new Float32Array(16));
     this.inputPoses = new WeakMap(); // Map of XRCoordinateSystem:XRInputPose
+    this.primaryButtonIndex = primaryButtonIndex;
     this.primaryActionPressed = false;
   }
 

--- a/src/api/XRInputSource.js
+++ b/src/api/XRInputSource.js
@@ -90,7 +90,7 @@ export class XRInputSourceImpl {
     }
     // TODO: The pointer matrix should probably be tweaked a bit.
     coordinateSystem.transformBasePoseMatrix(inputPose.pointerMatrix, this.basePoseMatrix);
-    if (inputPose.pointerMatrix) {
+    if (inputPose.gripMatrix) {
       coordinateSystem.transformBasePoseMatrix(inputPose.gripMatrix, this.basePoseMatrix);
     }
     return inputPose;

--- a/src/api/XRInputSource.js
+++ b/src/api/XRInputSource.js
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XRInputPose from './XRInputPose';
+import { mat4_identity, mat4_fromRotationTranslation, mat4_copy } from '../math';
+
+const PRIVATE = Symbol('@@webxr-polyfill/XRInputSource');
+
+const HEAD_CONTROLLER_RIGHT_OFFSET = new Float32Array([0.155, -0.465, -0.35]);
+const HEAD_CONTROLLER_LEFT_OFFSET = new Float32Array([-0.155, -0.465, -0.35]);
+
+export class XRInputSourceImpl {
+  constructor(polyfill) {
+    this.polyfill = polyfill;
+    this.gamepad = null;
+    this.inputSource = new XRInputSource(this);
+    this.lastPosition = new Float32Array(3);
+    this.emulatedPosition = false;
+    this.basePoseMatrix = mat4_identity(new Float32Array(16));
+    this.inputPoses = new WeakMap(); // Map of XRCoordinateSystem:XRInputPose
+  }
+
+  updateFromGamepad(gamepad) {
+    this.gamepad = gamepad;
+    this.inputSource[PRIVATE].handedness = gamepad.hand;
+
+    if (gamepad.pose) {
+      this.inputSource[PRIVATE].pointerOrigin = 'hand';
+      this.emulatedPosition = !gamepad.pose.hasPosition;
+    } else if (gamepad.hand === '') {
+      this.inputSource[PRIVATE].pointerOrigin = 'head';
+      this.emulatedPosition = false;
+    }
+  }
+
+  updateBasePoseMatrix() {
+    if (this.gamepad && this.gamepad.pose) {
+      let pose = this.gamepad.pose;
+      let position = pose.position;
+      let orientation = pose.orientation;
+      // On initialization, we might not have any values
+      if (!position && !orientation) {
+        return;
+      }
+      if (!position) {
+        if (!pose.hasPosition) {
+          // TODO: Should do an elbow model here.
+          if (this.gamepad.hand == 'left') {
+            position = HEAD_CONTROLLER_LEFT_OFFSET;
+          } else {
+            position = HEAD_CONTROLLER_RIGHT_OFFSET;
+          }
+        } else {
+          position = this.lastPosition;
+        }
+      } else {
+        // This is if we temporarily lose tracking, so the controller doesn't
+        // snap back to the origin.
+        this.lastPosition[0] = position[0];
+        this.lastPosition[1] = position[1];
+        this.lastPosition[2] = position[2];
+      }
+      mat4_fromRotationTranslation(this.basePoseMatrix, orientation, position);
+    } else {
+      mat4_copy(this.basePoseMatrix, this.polyfill.getBasePoseMatrix());
+    }
+    return this.basePoseMatrix;
+  }
+
+  getXRInputPose(coordinateSystem) {
+    this.updateBasePoseMatrix();
+    let inputPose = this.inputPoses.get(coordinateSystem);
+    if (!inputPose) {
+      inputPose = new XRInputPose(this, this.gamepad && this.gamepad.pose);
+      this.inputPoses.set(coordinateSystem, inputPose);
+    }
+    // TODO: The pointer matrix should probably be tweaked a bit.
+    coordinateSystem.transformBasePoseMatrix(inputPose.pointerMatrix, this.basePoseMatrix);
+    if (inputPose.pointerMatrix) {
+      coordinateSystem.transformBasePoseMatrix(inputPose.gripMatrix, this.basePoseMatrix);
+    }
+    return inputPose;
+  }
+}
+
+export class XRInputSource {
+  /**
+   * @param {XRHandedness} handedness
+   * @param {XRPointerOrigin} pointerOrigin
+   * @param {number} sessionId
+   */
+  constructor(impl) {
+    this[PRIVATE] = {
+      impl,
+      handedness: '',
+      pointerOrigin: 'head'
+    };
+  }
+
+  /**
+   * @return {XRHandedness}
+   */
+  get handedness() { return this[PRIVATE].handedness; }
+
+  /**
+   * @return {XRPointerOrigin}
+   */
+  get pointerOrigin() { return this[PRIVATE].pointerOrigin; }
+}

--- a/src/api/XRPresentationFrame.js
+++ b/src/api/XRPresentationFrame.js
@@ -62,4 +62,13 @@ export default class XRPresentationFrame {
     this[PRIVATE].devicePose.updateFromFrameOfReference(coordinateSystem);
     return this[PRIVATE].devicePose;
   }
+
+  /**
+   * @param {XRInputSource} inputSource
+   * @param {XRCoordinateSystem} coordinateSystem
+   * @return {XRInputPose?}
+   */
+  getInputPose(inputSource, coordinateSystem) {
+    return this[PRIVATE].polyfill.getInputPose(inputSource, coordinateSystem);
+  }
 }

--- a/src/api/XRSession.js
+++ b/src/api/XRSession.js
@@ -273,7 +273,7 @@ export default class XRSession extends EventTarget {
    * @return {Array<XRInputSource>} input sources
    */
   getInputSources() {
-    return [];
+    return this[PRIVATE].polyfill.getInputSources();
   }
 
   async end() {

--- a/src/api/XRSession.js
+++ b/src/api/XRSession.js
@@ -103,6 +103,8 @@ export default class XRSession extends EventTarget {
       this[PRIVATE].ended = true;
       polyfill.removeEventListener('@webvr-polyfill/vr-present-end', this[PRIVATE].onPresentationEnd);
       polyfill.removeEventListener('@webvr-polyfill/vr-present-start', this[PRIVATE].onPresentationStart);
+      polyfill.removeEventListener('@@webvr-polyfill/input-select-start', this[PRIVATE].onSelectStart);
+      polyfill.removeEventListener('@@webvr-polyfill/input-select-end', this[PRIVATE].onSelectEnd);
       this.dispatchEvent('end', { session: this });
     };
     polyfill.addEventListener('@@webxr-polyfill/vr-present-end', this[PRIVATE].onPresentationEnd);
@@ -120,6 +122,38 @@ export default class XRSession extends EventTarget {
       this.dispatchEvent('blur', { session: this });
     };
     polyfill.addEventListener('@@webxr-polyfill/vr-present-start', this[PRIVATE].onPresentationStart);
+
+    this[PRIVATE].onSelectStart = evt => {
+      // Ignore if this event is not for this session.
+      if (evt.sessionId !== this[PRIVATE].id) {
+        return;
+      }
+
+      this.dispatchEvent('selectstart', {
+        frame: this[PRIVATE].frame,
+        inputSource: evt.inputSource
+      });
+    };
+    polyfill.addEventListener('@@webxr-polyfill/input-select-start', this[PRIVATE].onSelectStart);
+
+    this[PRIVATE].onSelectEnd = evt => {
+      // Ignore if this event is not for this session.
+      if (evt.sessionId !== this[PRIVATE].id) {
+        return;
+      }
+
+      this.dispatchEvent('selectend', {
+        frame: this[PRIVATE].frame,
+        inputSource: evt.inputSource
+      });
+
+      // Sadly, there's no way to make this a user gesture.
+      this.dispatchEvent('select',  {
+        frame: this[PRIVATE].frame,
+        inputSource: evt.inputSource
+      });
+    };
+    polyfill.addEventListener('@@webxr-polyfill/input-select-end', this[PRIVATE].onSelectEnd);
 
     this.onblur = undefined;
     this.onfocus = undefined;
@@ -289,6 +323,10 @@ export default class XRSession extends EventTarget {
                                                  this[PRIVATE].onPresentationStart);
       this[PRIVATE].polyfill.removeEventListener('@@webvr-polyfill/vr-present-end',
                                                  this[PRIVATE].onPresentationEnd);
+      this[PRIVATE].polyfill.removeEventListener('@@webvr-polyfill/input-select-start',
+                                                 this[PRIVATE].onSelectStart);
+      this[PRIVATE].polyfill.removeEventListener('@@webvr-polyfill/input-select-end',
+                                                 this[PRIVATE].onSelectEnd);
 
       this.dispatchEvent('end', { session: this });
     }

--- a/src/api/XRSession.js
+++ b/src/api/XRSession.js
@@ -159,6 +159,9 @@ export default class XRSession extends EventTarget {
     this.onfocus = undefined;
     this.onresetpose = undefined;
     this.onend = undefined;
+    this.onselect = undefined;
+    this.onselectstart = undefined;
+    this.onselectend = undefined;
   }
 
   /**

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -20,6 +20,8 @@ import XRPresentationFrame from './XRPresentationFrame';
 import XRView from './XRView';
 import XRViewport from './XRViewport';
 import XRDevicePose from './XRDevicePose';
+import XRInputPose from './XRInputPose';
+import XRInputSource from './XRInputSource';
 import XRLayer from './XRLayer';
 import XRWebGLLayer from './XRWebGLLayer';
 import XRPresentationContext from './XRPresentationContext';

--- a/src/devices/GamepadXRInputSource.js
+++ b/src/devices/GamepadXRInputSource.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XRInputPose from '../api/XRInputPose';
+import XRInputSource from '../api/XRInputSource';
+import { mat4_identity, mat4_fromRotationTranslation, mat4_copy } from '../math';
+
+const HEAD_CONTROLLER_RIGHT_OFFSET = new Float32Array([0.155, -0.465, -0.35]);
+const HEAD_CONTROLLER_LEFT_OFFSET = new Float32Array([-0.155, -0.465, -0.35]);
+
+export default class GamepadXRInputSource {
+  constructor(polyfill, primaryButtonIndex = 0) {
+    this.polyfill = polyfill;
+    this.gamepad = null;
+    this.inputSource = new XRInputSource(this);
+    this.lastPosition = new Float32Array(3);
+    this.emulatedPosition = false;
+    this.basePoseMatrix = mat4_identity(new Float32Array(16));
+    this.inputPoses = new WeakMap(); // Map of XRCoordinateSystem:XRInputPose
+    this.primaryButtonIndex = primaryButtonIndex;
+    this.primaryActionPressed = false;
+    this.handedness = '';
+    this.pointerOrigin = 'head';
+  }
+
+  updateFromGamepad(gamepad) {
+    this.gamepad = gamepad;
+    this.handedness = gamepad.hand;
+
+    if (gamepad.pose) {
+      this.pointerOrigin = 'hand';
+      this.emulatedPosition = !gamepad.pose.hasPosition;
+    } else if (gamepad.hand === '') {
+      this.pointerOrigin = 'head';
+      this.emulatedPosition = false;
+    }
+  }
+
+  updateBasePoseMatrix() {
+    if (this.gamepad && this.gamepad.pose) {
+      let pose = this.gamepad.pose;
+      let position = pose.position;
+      let orientation = pose.orientation;
+      // On initialization, we might not have any values
+      if (!position && !orientation) {
+        return;
+      }
+      if (!position) {
+        if (!pose.hasPosition) {
+          // TODO: Should do an elbow model here.
+          if (this.gamepad.hand == 'left') {
+            position = HEAD_CONTROLLER_LEFT_OFFSET;
+          } else {
+            position = HEAD_CONTROLLER_RIGHT_OFFSET;
+          }
+        } else {
+          position = this.lastPosition;
+        }
+      } else {
+        // This is if we temporarily lose tracking, so the controller doesn't
+        // snap back to the origin.
+        this.lastPosition[0] = position[0];
+        this.lastPosition[1] = position[1];
+        this.lastPosition[2] = position[2];
+      }
+      mat4_fromRotationTranslation(this.basePoseMatrix, orientation, position);
+    } else {
+      mat4_copy(this.basePoseMatrix, this.polyfill.getBasePoseMatrix());
+    }
+    return this.basePoseMatrix;
+  }
+
+  getXRInputPose(coordinateSystem) {
+    this.updateBasePoseMatrix();
+    let inputPose = this.inputPoses.get(coordinateSystem);
+    if (!inputPose) {
+      inputPose = new XRInputPose(this, this.gamepad && this.gamepad.pose);
+      this.inputPoses.set(coordinateSystem, inputPose);
+    }
+    // TODO: The pointer matrix should probably be tweaked a bit.
+    coordinateSystem.transformBasePoseMatrix(inputPose.pointerMatrix, this.basePoseMatrix);
+    if (inputPose.gripMatrix) {
+      coordinateSystem.transformBasePoseMatrix(inputPose.gripMatrix, this.basePoseMatrix);
+    }
+    return inputPose;
+  }
+}

--- a/src/devices/PolyfilledXRDevice.js
+++ b/src/devices/PolyfilledXRDevice.js
@@ -76,7 +76,7 @@ export default class PolyfilledXRDevice extends EventTarget {
   /**
    * @return {Function}
    */
-  requestAnimationFrame(callback) { throw new Error('Not implemented'); }
+  requestAnimationFrame(callback, sessionId) { throw new Error('Not implemented'); }
 
   /**
    * @param {number} sessionId
@@ -152,6 +152,22 @@ export default class PolyfilledXRDevice extends EventTarget {
    * @return {Float32Array}
    */
   getBaseViewMatrix(eye) { throw new Error('Not implemented'); }
+
+  /**
+   * Get a list of input sources.
+   *
+   * @return {Array<XRInputSource>}
+   */
+  getInputSources() { throw new Error('Not implemented'); }
+
+  /**
+   * Get the current pose of an input source.
+   *
+   * @param {XRInputSource} inputSource
+   * @param {XRCoordinateSystem} coordinateSystem
+   * @return {XRInputPose}
+   */
+  getInputPose(inputSource, coordinateSystem) { throw new Error('Not implemented'); }
 
   /**
    * Called on window resize.

--- a/src/devices/PolyfilledXRDevice.js
+++ b/src/devices/PolyfilledXRDevice.js
@@ -76,7 +76,7 @@ export default class PolyfilledXRDevice extends EventTarget {
   /**
    * @return {Function}
    */
-  requestAnimationFrame(callback, sessionId) { throw new Error('Not implemented'); }
+  requestAnimationFrame(callback) { throw new Error('Not implemented'); }
 
   /**
    * @param {number} sessionId

--- a/src/devices/WebVRDevice.js
+++ b/src/devices/WebVRDevice.js
@@ -15,11 +15,11 @@
 
 import global from '../lib/global';
 import PolyfilledXRDevice from './PolyfilledXRDevice';
+import GamepadXRInputSource from './GamepadXRInputSource';
 import XRDevice from '../api/XRDevice';
 import XRPresentationFrame from '../api/XRPresentationFrame';
 import XRView from '../api/XRView';
 import XRDevicePose from '../api/XRDevicePose';
-import { XRInputSourceImpl } from '../api/XRInputSource';
 import XRInputPose from '../api/XRInputPose';
 import { mat4_fromRotationTranslation, mat4_identity, perspective } from '../math';
 import { applyCanvasStylesForMinimalRendering } from '../utils';
@@ -256,7 +256,7 @@ export default class WebVRDevice extends PolyfilledXRDevice {
           // Found a gamepad input source for this index.
           let inputSourceImpl = prevInputSources[i];
           if (!inputSourceImpl) {
-            inputSourceImpl = new XRInputSourceImpl(this, this.getPrimaryButtonIndex(gamepad));
+            inputSourceImpl = new GamepadXRInputSource(this, this.getPrimaryButtonIndex(gamepad));
           }
           inputSourceImpl.updateFromGamepad(gamepad);
           this.gamepadInputSources[i] = inputSourceImpl;

--- a/src/devices/WebVRDevice.js
+++ b/src/devices/WebVRDevice.js
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import global from '../lib/global';
 import PolyfilledXRDevice from './PolyfilledXRDevice';
 import XRDevice from '../api/XRDevice';
 import XRPresentationFrame from '../api/XRPresentationFrame';
@@ -38,6 +39,8 @@ const PRIMARY_BUTTON_MAP = {
   oculus: 1,
   openvr: 1
 };
+
+const CAN_USE_GAMEPAD = global.navigator && ('getGamepads' in global.navigator);
 
 /**
  * A Session helper class to mirror an XRSession and correlate
@@ -242,11 +245,11 @@ export default class WebVRDevice extends PolyfilledXRDevice {
 
     const session = this.sessions.get(sessionId);
 
-    if (session.exclusive) {
+    if (session.exclusive && CAN_USE_GAMEPAD) {
       // Update inputs from gamepad data
       let prevInputSources = this.gamepadInputSources;
       this.gamepadInputSources = {};
-      let gamepads = navigator.getGamepads();
+      let gamepads = global.navigator.getGamepads();
       for (let i = 0; i < gamepads.length; ++i) {
         let gamepad = gamepads[i];
         if (gamepad && gamepad.displayId === this.display.displayId) {


### PR DESCRIPTION
Tested on Oculus Go, Vive, Daydream, and Cardboard over WebVR 1.1. 3DoF controllers lack an arm model and magic window input is missing, but this is a good first step.