### PR TITLE
Also extend WebGL2RenderingContext

### DIFF
--- a/src/WebXRPolyfill.js
+++ b/src/WebXRPolyfill.js
@@ -34,7 +34,7 @@ const CONFIG_DEFAULTS = {
   cardboard: true,
 };
 
-const partials = ['navigator', 'HTMLCanvasElement', 'WebGLRenderingContext'];
+const partials = ['navigator', 'HTMLCanvasElement', 'WebGLRenderingContext', 'WebGL2RenderingContext'];
 
 export default class WebXRPolyfill {
   /**
@@ -84,6 +84,8 @@ export default class WebXRPolyfill {
       // `ctx.getContext('xrpresent')`
       if (polyfilledCtx) {
         extendGetContext(global.HTMLCanvasElement);
+
+        extendContextCompatibleXRDevice(global.WebGL2RenderingContext);
       }
     }
 

--- a/test/lib/globals.js
+++ b/test/lib/globals.js
@@ -34,6 +34,7 @@ export class MockGlobal {
     this.navigator = window.navigator;
     this.HTMLCanvasElement = {};
     this.WebGLRenderingContext = {};
+    this.WebGL2RenderingContext = {};
   }
 }
 


### PR DESCRIPTION
Hi @toji !

I'm using WebXR with WebGL2 and it seems that Firefox is unable to find `setCompatibleXRDevice(...)` on a WebGL2 rendering context, if it is not explicitly extended also.

Cheers, Jonathan.