### PR TITLE
Implement support for OffscreenCanvas, as well as use ImageBitmapRenderingContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Check the [.babelrc](.babelrc) configuration and ensure the polyfill runs in wha
   * If `WebGLRenderingContext.prototype.setCompatibleXRDevice` is not a function:
     * Polyfill all `WebGLRenderingContext.prototype.setCompatibleXRDevice` and a creation attribute
 for `{ compatibleXrDevice }`.
-    * Polyfills `HTMLCanvasElement.prototype.getContext` to support a `xrpresent` type. Returns a polyfilled `XRPresentationContext` used for mirroring and magic window.
+    * Polyfills `HTMLCanvasElement.prototype.getContext` to support a `xrpresent` type. Returns a polyfilled `XRPresentationContext` (via `CanvasRenderingContext2D` or `ImageBitmapRenderingContext` if supported) used for mirroring and magic window.
 * If `'xr' in navigator === true`, `config.cardboard === true` and on mobile:
   * Overwrite `navigator.xr.requestDevice` so that a native `XRDevice` is returned if it exists, and if not, return a polyfilled `XRDevice` based on [CardboardVRDisplay].
 

--- a/examples/offscreen-canvas.html
+++ b/examples/offscreen-canvas.html
@@ -1,0 +1,177 @@
+<!doctype html>
+<!--
+Copyright 2018 The Immersive Web Community Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+-->
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <meta name='viewport' content='width=device-width, initial-scale=1, user-scalable=no'>
+    <meta name='mobile-web-app-capable' content='yes'>
+    <meta name='apple-mobile-web-app-capable' content='yes'>
+
+    <title>Offscreen Canvas</title>
+
+    <link href='css/common.css' rel='stylesheet'></link>
+
+    <script src='../build/webxr-polyfill.js'></script>
+    <script>
+        window.polyfill = new WebXRPolyfill();
+    </script>
+    <script src='js/gl-matrix-min.js'></script>
+    <script src='js/cottontail.js'></script>
+    <script src='js/webxr-button.js'></script>
+  </head>
+  <body>
+    <header>
+      <details open>
+        <summary>Offscreen Canvas</summary>
+        <p>
+          This sample demonstrates use of a non-immersive XRSession to present
+          'Magic Window' rendered from an OffscreenCanvas.
+        </p>
+      </details>
+    </header>
+    <script>
+      (function () {
+      'use strict';
+
+      // XR globals.
+      let xrButton = null;
+      let xrExclusiveFrameOfRef = null;
+      let xrNonExclusiveFrameOfRef = null;
+
+      // WebGL scene globals.
+      let gl = null;
+      let renderer = null;
+      let scene = new CubeSeaScene();
+
+      function initXR() {
+        xrButton = new XRDeviceButton({
+          onRequestSession: onRequestSession,
+          onEndSession: onEndSession
+        });
+        document.querySelector('header').appendChild(xrButton.domElement);
+
+        if (navigator.xr) {
+          navigator.xr.requestDevice().then((device) => {
+            xrButton.setDevice(device);
+
+            if (!device)
+              return;
+
+            // In order for a non-immersive session to be used we must provide
+            // an outputContext, which indicates the canvas that will contain
+            // results of the session's rendering.
+            let outputCanvas = document.createElement('canvas');
+            let ctx = outputCanvas.getContext('xrpresent');
+
+            // Pick an arbitrary device for the magic window content and start
+            // up a non-immersive session if possible.
+            device.requestSession({ outputContext: ctx })
+                .then((session) => {
+                  // Add the canvas to the document once we know that it will be
+                  // rendered to.
+                  document.body.appendChild(outputCanvas);
+                  onSessionStarted(session);
+                });
+          });
+        }
+      }
+
+      function onRequestSession(device) {
+        device.requestSession({ immersive: true }).then((session) => {
+          xrButton.setSession(session);
+          onSessionStarted(session);
+        });
+      }
+
+      function onSessionStarted(session) {
+        session.addEventListener('end', onSessionEnded);
+
+        if (!gl) {
+          let offscreenCanvas = new OffscreenCanvas(1, 1);
+          gl = offscreenCanvas.getContext('webgl', {
+            compatibleXRDevice: session.device
+          });
+
+          renderer = new Renderer(gl);
+
+          scene.setRenderer(renderer);
+        }
+
+        session.baseLayer = new XRWebGLLayer(session, gl);
+
+        session.requestFrameOfReference('eye-level').then((frameOfRef) => {
+          // Since we're dealing with multple sessions now we need to track
+          // which XRFrameOfReference is associated with which XRSession.
+          if (session.immersive) {
+            xrExclusiveFrameOfRef = frameOfRef;
+          } else {
+            xrNonExclusiveFrameOfRef = frameOfRef;
+          }
+          session.requestAnimationFrame(onXRFrame);
+        });
+      }
+
+      function onEndSession(session) {
+        session.end();
+      }
+
+      function onSessionEnded(event) {
+        // Only reset the button when the immersive session ends.
+        if (event.session.immersive)
+          xrButton.setSession(null);
+      }
+
+      // Called every time a XRSession requests that a new frame be drawn.
+      function onXRFrame(t, frame) {
+        let session = frame.session;
+        // Ensure that we're using the right frame of reference for the session.
+        let frameOfRef = session.immersive ?
+                         xrExclusiveFrameOfRef :
+                         xrNonExclusiveFrameOfRef;
+        let pose = frame.getDevicePose(frameOfRef);
+
+        scene.startFrame();
+
+        session.requestAnimationFrame(onXRFrame);
+
+        gl.bindFramebuffer(gl.FRAMEBUFFER, session.baseLayer.framebuffer);
+        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+        if (pose) {
+          for (let view of frame.views) {
+            let viewport = session.baseLayer.getViewport(view);
+            gl.viewport(viewport.x, viewport.y,
+                        viewport.width, viewport.height);
+
+            scene.draw(view.projectionMatrix, pose.getViewMatrix(view));
+          }
+        }
+
+        scene.endFrame();
+      }
+
+      // Start the XR application.
+      initXR();
+      })();
+    </script>
+  </body>
+</html>

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,6 +17,16 @@ import XRRay from './api/XRRay';
 import DOMPointReadOnly from './lib/DOMPointReadOnly';
 
 /**
+ * Whether or an ImageBitMapRenderingContext should be used to polyfill
+ * an XRPresentationContext.
+ *
+ * @return {Boolean}
+ */
+export const isImageBitmapSupported = global =>
+  !!(global.ImageBitmapRenderingContext &&
+     global.createImageBitmap);
+
+/**
  * Takes a pose matrix from a controller and return
  * an XRRay representing the pose.
  *


### PR DESCRIPTION
With [OffscreenCanvas](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas) in Chrome 69, I wanted to explore using ImageBitmaps to reduce the canvas copying from input context to XRPresentationContext via CanvasRenderingContext2D's `drawImage`.

In this PR, if [ImageBitmapRenderingContext](https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmapRenderingContext) is available (same spec as OffscreenCanvas, practically speaking will probably exist if OffscreenCanvas does?), the XRPresentationContext will be created using that instead. This means if using a non-OffscreenCanvas, we'll asynchronously create a bitmap via [createImageBtimap](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/createImageBitmap); if using an OffscreenCanvas, this just directly calls [OffscreenCanvas#transferImageToBitmap](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/createImageBitmap), which is the most ideal case, I think.

If using OffscreenCanvas without ImageBitmapRenderingContext support, CanvasRenderingContext2D's `drawImage` is still used. I'm not sure if this scenario will occur practically.

Questions/Comments:

* In some test cases, I haven't noticed any performance changes in the examples here -- on a Pixel 1, all were 55+ fps. Need to make a beefier, GPU-heavy example
* Will we always be a frame behind on the async `createImageBitmap` function? `createImageBitmap(inputCanvas, ...).then(bitmap => outputCtx.transferImageToBitmap(bitmap))`
* This OffscreenCanvas demo has the canvas on the main thread anyway. I'm not sure how WebXR Device API handles the OC being in a worker from a MT Canvas transferring control to an OC. Is the context even still available in MT to pass into WebXR?
* Are there any feature detection scenarios missing?