### PR TITLE
doc: Update Spec URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ In the future, when the WebXR API is implemented on a platform but inconsistent 
 This program is free software for both commercial and non-commercial use,
 distributed under the [Apache 2.0 License](LICENSE).
 
-[webxr-spec]: https://immersive-web.github.io/webxr/spec/latest/
+[webxr-spec]: https://immersive-web.github.io/webxr/
 [webvr-spec]: https://immersive-web.github.io/webvr/spec/1.1/
 [webvr-polyfill]: https://github.com/immersive-web/webvr-polyfill
 [npm]: https://www.npmjs.com


### PR DESCRIPTION
Current link to specs is broken (404 error)

Change-Id: I7e6b351001e1161faad198642959e74bfd7c3774
Signed-off-by: Philippe Coval <p.coval@samsung.com>