### PR TITLE
Updated Gamepad mapping to check displayName

### DIFF
--- a/src/devices/GamepadMappings.js
+++ b/src/devices/GamepadMappings.js
@@ -20,13 +20,20 @@ gamepad values to pass through unchanged.
 "Gamepad ID String": { // The Gamepad.id that this entry maps to.
   mapping: 'xr-standard', // Overrides the Gamepad.mapping that is reported
   profiles: ['gamepad-id-string'], // The profiles array that should be reported
+  displayProfiles: {
+    // Alternative profiles arrays to report if the VRDevice.displayName matches
+    "WebVR Display Name": ['gamepad-id-string']
+  },
   axes: { // Remaps the reported axes
     length: 2, // Overrides the length of the reported axes array
+    invert: [0] // List of mapped axes who's value should be inverted
     0: 2, // Remaps axes[0] to report axis[2] from the original gamepad object
+    1: null, // Remaps axes[1] to a placeholder axis (always reports 0)
   },
   buttons: { // Remaps the reported buttons
     length: 2, // Overrides the length of the reported buttons array
     0: 2, // Remaps buttons[0] to report buttons[2] from the original gamepad object
+    1: null // Remaps buttons[1] to a placeholder button (always reports 0/false)
   },
   gripTransform: { // An additional transform to apply to the gripSpace's pose
     position: [0, 0, 0.5], // Additional translation vector to apply
@@ -39,9 +46,27 @@ gamepad values to pass through unchanged.
 }
 */
 
+let oculusGo = {
+  mapping: 'xr-standard',
+  profiles: ['oculus-go', 'touchpad-controller'],
+  buttons: {
+    length: 3,
+    0: 1,
+    1: null,
+    2: 0
+  },
+  // Grip adjustments determined experimentally.
+  gripTransform: {
+    orientation: [Math.PI * 0.11, 0, 0, 1]
+  }
+};
+
 // Applies to both left and right Oculus Touch controllers.
 let oculusTouch = {
   mapping: 'xr-standard',
+  displayProfiles: {
+    'Oculus Quest': ['oculus-quest', 'oculus-touch', 'thumbstick-controller']
+  },
   profiles: ['oculus-touch', 'thumbstick-controller'],
   axes: {
     length: 4,
@@ -66,6 +91,28 @@ let oculusTouch = {
   }
 };
 
+let openVr = {
+  mapping: 'xr-standard',
+  profiles: ['openvr-controller', 'touchpad-controller'],
+  displayProfiles: {
+    'HTC Vive': ['htc-vive', 'touchpad-controller'],
+    'HTC Vive DVT': ['htc-vive', 'touchpad-controller']
+  },
+  buttons: {
+    length: 3,
+    0: 1,
+    1: 2,
+    2: 0
+  },
+  // Transform adjustments determined experimentally.
+  gripTransform: {
+    position: [0, 0, 0.05, 1],
+  },
+  targetRayTransform: {
+    orientation: [Math.PI * -0.08, 0, 0, 1]
+  }
+};
+
 let windowsMixedReality = {
   mapping: 'xr-standard',
   profiles: ['windows-mixed-reality', 'touchpad-thumbstick-controller'],
@@ -84,26 +131,12 @@ let windowsMixedReality = {
 };
 
 let GamepadMappings = {
-  "Oculus Touch (Right)": oculusTouch,
-  "Oculus Touch (Left)": oculusTouch,
-
-  "Oculus Go Controller": {
-    mapping: 'xr-standard',
-    profiles: ['oculus-go', 'touchpad-controller'],
-    buttons: {
-      length: 3,
-      0: 1,
-      1: null,
-      2: 0
-    },
-    // Grip adjustments determined experimentally.
-    gripTransform: {
-      orientation: [Math.PI * 0.11, 0, 0, 1]
-    }
-  },
-
-  "Windows Mixed Reality (Right)": windowsMixedReality,
-  "Windows Mixed Reality (Left)": windowsMixedReality,
+  'Oculus Go Controller': oculusGo,
+  'Oculus Touch (Right)': oculusTouch,
+  'Oculus Touch (Left)': oculusTouch,
+  'OpenVR Gamepad': openVr,
+  'Windows Mixed Reality (Right)': windowsMixedReality,
+  'Windows Mixed Reality (Left)': windowsMixedReality,
 };
 
 export default GamepadMappings;

--- a/src/devices/GamepadXRInputSource.js
+++ b/src/devices/GamepadXRInputSource.js
@@ -26,7 +26,7 @@ const PLACEHOLDER_BUTTON = { pressed: false, touched: false, value: 0.0 };
 Object.freeze(PLACEHOLDER_BUTTON);
 
 class XRRemappedGamepad {
-  constructor(gamepad, map) {
+  constructor(gamepad, display, map) {
     if (!map) {
       map = {};
     }
@@ -56,10 +56,17 @@ class XRRemappedGamepad {
       );
     }
 
+    let profiles = map.profiles;
+    if (map.displayProfiles) {
+      if (display.displayName in map.displayProfiles) {
+        profiles = map.displayProfiles[display.displayName];
+      }
+    }
+
     this[PRIVATE] = {
       gamepad,
       map,
-      profiles: map.profiles || [gamepad.id],
+      profiles: profiles || [gamepad.id],
       mapping: map.mapping || gamepad.mapping,
       axes,
       buttons,
@@ -84,6 +91,12 @@ class XRRemappedGamepad {
         }
       } else {
         axes[i] = gamepad.axes[i];
+      }
+    }
+
+    if (map.axes && map.axes.invert) {
+      for (let axis of map.axes.invert) {
+        axes[axis] *= -1;
       }
     }
 
@@ -135,8 +148,9 @@ class XRRemappedGamepad {
 }
 
 export default class GamepadXRInputSource {
-  constructor(polyfill, primaryButtonIndex = 0) {
+  constructor(polyfill, display, primaryButtonIndex = 0) {
     this.polyfill = polyfill;
+    this.display = display;
     this.nativeGamepad = null;
     this.gamepad = null;
     this.inputSource = new XRInputSource(this);
@@ -159,7 +173,7 @@ export default class GamepadXRInputSource {
     if (this.nativeGamepad !== gamepad) {
       this.nativeGamepad = gamepad;
       if (gamepad) {
-        this.gamepad = new XRRemappedGamepad(gamepad, GamepadMappings[gamepad.id]);
+        this.gamepad = new XRRemappedGamepad(gamepad, this.display, GamepadMappings[gamepad.id]);
       } else {
         this.gamepad = null;
       }

--- a/src/devices/WebVRDevice.js
+++ b/src/devices/WebVRDevice.js
@@ -289,7 +289,7 @@ export default class WebVRDevice extends XRDevice {
           // Found a gamepad input source for this index.
           let inputSourceImpl = prevInputSources[i];
           if (!inputSourceImpl) {
-            inputSourceImpl = new GamepadXRInputSource(this, this.getPrimaryButtonIndex(gamepad));
+            inputSourceImpl = new GamepadXRInputSource(this, this.display, this.getPrimaryButtonIndex(gamepad));
           }
           inputSourceImpl.updateFromGamepad(gamepad);
           this.gamepadInputSources[i] = inputSourceImpl;


### PR DESCRIPTION
This allows a different set of profiles to be exposed based on the
displayName even if the gamepad.id matches. The primary example of this
is Oculus Quest, where the controller identifies as an Oculus Touch and
the mapping is identical, but the mesh should be different than the one
used by an Oculus Rift.

Also added the ability to invert axes during mapping if needed. This has
proven to be necessary with some WebVR devices.

Addresses https://github.com/immersive-web/webxr-input-profiles/issues/44,
and enables similar mapping in the future with APIs like OpenVR (which I
need to do some hands-on testing with prior to mapping.)