### PR TITLE
Fix return values from XR.supportsSession()

### DIFF
--- a/src/api/XR.js
+++ b/src/api/XR.js
@@ -58,11 +58,11 @@ export default class XR extends EventTarget {
     // 'inline' is always guaranteed to be supported.
     if (mode != 'inline') {
       if (!this[PRIVATE].device.supportsSession(mode)) {
-        return Promise.reject(null);
+        return Promise.reject(new DOMException('The specified session configuration is not supported.'));
       }
     } 
 
-    return Promise.resolve(null);
+    return Promise.resolve();
   }
 
   /**


### PR DESCRIPTION
This PR lets the return values from `XR.supportsSession()` follow the specification.

Currently it returns `Promise.resolve(null)` when succeeded and returns `Promise.reject(null)` when failed. But [the specification](https://immersive-web.github.io/webxr/#xr-interface) mentions that the return type is `Promise<void>` when succeeded and `reject promise with a "NotSupportedError" DOMException` when failed.