### PR TITLE
Set none to XRInputSource.handedness if gamepad.hand is empty string

### DIFF
--- a/build/webxr-polyfill.js
+++ b/build/webxr-polyfill.js
@@ -5643,7 +5643,7 @@ class GamepadXRInputSource {
         this.gamepad = null;
       }
     }
-    this.handedness = gamepad.hand;
+    this.handedness = gamepad.hand === '' ? 'none' : gamepad.hand;
     if (this.gamepad) {
       this.gamepad._update();
     }


### PR DESCRIPTION
The polyfill updates `XRInputSource.handedness` from `gamepad.hand`.

`Gamepad.hand` enum is `'left'`, `'right'`, or `''` while `XRInputSrouce.handedness` (`XRHandedness`) enum is `'left'`, `'right'`, or `'none'`.

https://developer.mozilla.org/en-US/docs/Web/API/Gamepad/hand
https://www.w3.org/TR/webxr/#xrinputsource-interface

Then I think the polyfill should sets `none` to `XRInputSource.handedness` if `gamepad.hand` is `''` rather than always just copying `gamepad.hand` to `XRInputSource.handedness`.