### PR TITLE
XRSession initial renderState should not be null

### DIFF
--- a/src/api/XRSession.js
+++ b/src/api/XRSession.js
@@ -19,6 +19,7 @@ import XRFrame from './XRFrame';
 import XRReferenceSpace, {
   XRReferenceSpaceTypes
 } from './XRReferenceSpace';
+import XRRenderState from './XRRenderState';
 import XRWebGLLayer from './XRWebGLLayer';
 import XRInputSourceEvent from './XRInputSourceEvent';
 import XRSessionEvent from './XRSessionEvent';
@@ -47,7 +48,7 @@ export default class XRSession extends EventTarget {
       suspended: false,
       suspendedCallback: null,
       id,
-      activeRenderState: null,
+      activeRenderState: new XRRenderState(),
       pendingRenderState: null,
       currentInputSources: []
     };


### PR DESCRIPTION
From #98

IIRC, initial `renderState` (active render state) of `XRSession` shouldn't be `null`, but should be new `XRRenderState`.

https://immersive-web.github.io/webxr/#xrsession-interface

> Each XRSession has an active render state which is a new XRRenderState,

> The renderState attribute returns the XRSession's active render state.