### PR TITLE
Fix a bug that end event isn't fired for immersive session

### DIFF
--- a/src/api/XRSession.js
+++ b/src/api/XRSession.js
@@ -333,7 +333,7 @@ export default class XRSession extends EventTarget {
 
     // If this is an immersive session, trigger the platform to end, which
     // will call the `onPresentationEnd` handler, wrapping this up.
-    if (!this.immersive) {
+    if (this.immersive) {
       this[PRIVATE].ended = true;
       this[PRIVATE].device.removeEventListener('@@webvr-polyfill/vr-present-start',
                                                  this[PRIVATE].onPresentationStart);


### PR DESCRIPTION
The comment tn `XRSession.end` mentions

```
    // If this is an immersive session, trigger the platform to end, which
    // will call the `onPresentationEnd` handler, wrapping this up.
```

But end event is fired if session is not immersive. I speculate `if (!this.immersive)` should've been `if (this.immersive)`.

This PR fixes this bug.