### PR TITLE
Fixes to updateRenderState

### DIFF
--- a/src/api/XRRenderState.js
+++ b/src/api/XRRenderState.js
@@ -25,7 +25,7 @@ export const XRRenderStateInit = Object.freeze({
 // TODO: inlineVerticalFieldOfView must be PI * 0.5 for non-immersive sessions.
 export default class XRRenderState {
   /**
-   * @param {Object?} stateInit 
+   * @param {Object?} stateInit
    */
   constructor(stateInit = {}) {
     const config = Object.assign({}, XRRenderStateInit, stateInit);
@@ -35,20 +35,20 @@ export default class XRRenderState {
   /**
    * @return {number}
    */
-  get depthNear() { return this[PRIVATE].depthNear; }
+  get depthNear() { return this[PRIVATE].config.depthNear; }
 
   /**
    * @return {number}
    */
-  get depthFar() { return this[PRIVATE].depthFar; }
+  get depthFar() { return this[PRIVATE].config.depthFar; }
 
   /**
    * @return {number?}
    */
-  get inlineVerticalFieldOfView() { return this[PRIVATE].inlineVerticalFieldOfView; }
+  get inlineVerticalFieldOfView() { return this[PRIVATE].config.inlineVerticalFieldOfView; }
 
   /**
    * @return {XRWebGLLayer}
    */
-  get baseLayer() { return this[PRIVATE].baseLayer; }
+  get baseLayer() { return this[PRIVATE].config.baseLayer; }
 }

--- a/src/api/XRSession.js
+++ b/src/api/XRSession.js
@@ -278,7 +278,7 @@ export default class XRSession extends EventTarget {
     return this[PRIVATE].device.requestAnimationFrame(() => {
       if (this[PRIVATE].pendingRenderState !== null) {
         // Apply pending render state.
-        this[PRIVATE].activeRenderState = this[PRIVATE].pendingRenderState;
+        this[PRIVATE].activeRenderState = new XRRenderState(this[PRIVATE].pendingRenderState);
         this[PRIVATE].pendingRenderState = null;
 
         // TODO: set compositionDisabled
@@ -386,10 +386,9 @@ export default class XRSession extends EventTarget {
     }
 
     if (this[PRIVATE].pendingRenderState === null) {
-      // Clone pendingRenderState and override any fields that are set by newState.
-      this[PRIVATE].pendingRenderState = Object.assign(
-        {}, this[PRIVATE].activeRenderState, newState);
+      this[PRIVATE].pendingRenderState = Object.assign({}, this[PRIVATE].activeRenderState);
     }
+    Object.assign(this[PRIVATE].pendingRenderState, newState);
   }
 
   /**


### PR DESCRIPTION
- Fix multiple calls to updateRenderState within the same frame -- subsequent calls were being ignored.
- Make the resulting active renderState a XRRenderState instance.

Tests fail but they appear to be generally broken so assuming that's ok.