### PR TITLE
Clean up XRViewerPose

### DIFF
--- a/src/api/XRViewerPose.js
+++ b/src/api/XRViewerPose.js
@@ -73,8 +73,7 @@ export default class XRViewerPose extends XRPose {
     if (leftViewMatrix) {
       refSpace._transformBaseViewMatrix(
         this[PRIVATE].leftViewMatrix,
-        leftViewMatrix,
-        this[PRIVATE].poseModelMatrix);
+        leftViewMatrix);
 
       mat4.multiply(
         this[PRIVATE].leftViewMatrix,
@@ -85,8 +84,7 @@ export default class XRViewerPose extends XRPose {
     if (rightViewMatrix) {
       refSpace._transformBaseViewMatrix(
         this[PRIVATE].rightViewMatrix,
-        rightViewMatrix,
-        this[PRIVATE].poseModelMatrix);
+        rightViewMatrix);
 
       mat4.multiply(
         this[PRIVATE].rightViewMatrix,


### PR DESCRIPTION
`XRReferenceSpace._transformBasePoseMatrix()` takes two arguments

https://github.com/immersive-web/webxr-polyfill/blob/master/src/api/XRReferenceSpace.js#L104

but `XRViewerPose` passes three arguments. This PR removes the unnecessary third argument.