### PR TITLE
Set none to XRInputSource.handedness if gamepad.hand is empty string

### DIFF
--- a/src/devices/GamepadXRInputSource.js
+++ b/src/devices/GamepadXRInputSource.js
@@ -178,7 +178,7 @@ export default class GamepadXRInputSource {
         this.gamepad = null;
       }
     }
-    this.handedness = gamepad.hand;
+    this.handedness = gamepad.hand === '' ? 'none' : gamepad.hand
 
     if (this.gamepad) {
       this.gamepad._update();


### PR DESCRIPTION
Sorry, I realized that I wrongly edited the code in `build/webxr-polyfill.js` although I should have edited in `src/devices/GamepadXRInputSource.js` in #96.

I made a new PR to apply the change in `src/devices/GamepadXRInputSource.js`.