### PR TITLE
Fix XRSession.updateRenderState() bug

### DIFF
--- a/src/api/XRSession.js
+++ b/src/api/XRSession.js
@@ -384,7 +384,13 @@ export default class XRSession extends EventTarget {
     }
 
     if (this[PRIVATE].pendingRenderState === null) {
-      this[PRIVATE].pendingRenderState = Object.assign({}, this[PRIVATE].activeRenderState);
+      const activeRenderState = this[PRIVATE].activeRenderState;
+      this[PRIVATE].pendingRenderState = {
+        depthNear: activeRenderState.depthNear,
+        depthFar: activeRenderState.depthFar,
+        inlineVerticalFieldOfView: activeRenderState.inlineVerticalFieldOfView,
+        baseLayer: activeRenderState.baseLayer
+      };
     }
     Object.assign(this[PRIVATE].pendingRenderState, newState);
   }


### PR DESCRIPTION
`XRSession.updateRenderState()` has a bug that properties which are not passed via `.updateRenderState()` will be overridden with the default values.

For example if you call `session.updateRenderState({ inlineVerticalFieldOfView: Math.PI })` where `session.renderState` is already initialized with certain values, `session.renderState.depthNear/depthFar/baseLayer` will be overridden with the default values `0.1/1000.0/null` in next frame

The root issue is the following line in `XRSession.updateRenderState()`.

```javascript
this[PRIVATE].pendingRenderState = Object.assign({}, this[PRIVATE].activeRenderState);
```

`.acriveRenderState` properties are hidden behind private `.activeRenderState[PRIVATE]` and getter methods so they can't be copied with `Object.assign({}, this[PRIVATE].activeRenderState)`.

This PR fixes it.

/CC @lojjic