### PR TITLE
Fixes for XR animation frame loop

### DIFF
--- a/src/api/XRFrame.js
+++ b/src/api/XRFrame.js
@@ -37,6 +37,8 @@ export default class XRFrame {
     }
 
     this[PRIVATE] = {
+      active: false,
+      animationFrame: false,
       device,
       viewerPose: new XRViewerPose(device, views),
       views,
@@ -54,6 +56,9 @@ export default class XRFrame {
    * @return {XRViewerPose?}
    */
   getViewerPose(space) {
+    if (!this[PRIVATE].animationFrame || !this[PRIVATE].active) {
+      throw new Error('InvalidStateError');
+    }
     this[PRIVATE].viewerPose._updateFromReferenceSpace(space);
     return this[PRIVATE].viewerPose;
   }
@@ -64,6 +69,9 @@ export default class XRFrame {
    * @return {XRPose?} pose
    */
   getPose(space, baseSpace) {
+    if (!this[PRIVATE].active) {
+      throw new Error('InvalidStateError');
+    }
     if (space._specialType === "viewer") {
       // Don't just return the viewer pose since the resulting pose shouldn't
       // include the views array - it should just have the transform.

--- a/src/api/XRFrame.js
+++ b/src/api/XRFrame.js
@@ -19,6 +19,9 @@ import { mat4 } from 'gl-matrix';
 
 export const PRIVATE = Symbol('@@webxr-polyfill/XRFrame');
 
+const NON_ACTIVE_MSG = "XRFrame access outside the callback that produced it is invalid.";
+const NON_ANIMFRAME_MSG = "getViewerPose can only be called on XRFrame objects passed to XRSession.requestAnimationFrame callbacks.";
+
 export default class XRFrame {
   /**
    * @param {XRDevice} device
@@ -56,8 +59,11 @@ export default class XRFrame {
    * @return {XRViewerPose?}
    */
   getViewerPose(space) {
-    if (!this[PRIVATE].animationFrame || !this[PRIVATE].active) {
-      throw new Error('InvalidStateError');
+    if (!this[PRIVATE].animationFrame) {
+      throw new DOMException(NON_ANIMFRAME_MSG, 'InvalidStateError');
+    }
+    if (!this[PRIVATE].active) {
+      throw new DOMException(NON_ACTIVE_MSG, 'InvalidStateError');
     }
     this[PRIVATE].viewerPose._updateFromReferenceSpace(space);
     return this[PRIVATE].viewerPose;
@@ -70,7 +76,7 @@ export default class XRFrame {
    */
   getPose(space, baseSpace) {
     if (!this[PRIVATE].active) {
-      throw new Error('InvalidStateError');
+      throw new DOMException(NON_ACTIVE_MSG, 'InvalidStateError');
     }
     if (space._specialType === "viewer") {
       // Don't just return the viewer pose since the resulting pose shouldn't


### PR DESCRIPTION
## Fixes: ##

- Issue #115: rework `xrSession.requestAnimationFrame` to use a single device frame handler and a list of callbacks, to match the spec algorithm and prevent multiple vrDisplay.submitFrame calls per frame
- Issue #114: Instantiate new XRFrame on each frame and each input source event dispatch
- Add `active` and `animationFrame` booleans to XRFrame, toggle them appropriately, and check them during pose population per spec

## Notes for Review: ##

- Given how central the frame loop is, please be very critical in reviewing this logic.
- My testing has been only on Oculus Quest, and only via my own framework code [edit: and the webxr-samples repo]. I would appreciate help testing on other devices, and if there are some other good testcases out there I should be aware of to run this against I'd love to know about them.
- The `test-xr-session.js` test file is busted so I haven't added anything there to test these changes, but I'd feel much better if I could, so I may try to at least get that one into a runnable state so I can add to it.
- I removed the `suspendedCallback` in favor of the callbacks array, and I _think_ the logic around suspension (pausing/restarting the device frame loop) is correct, but I don't know how to actually test the suspension. Tips welcome.