### PR TITLE
Misc cleanups for better spec compliance

### DIFF
--- a/src/api/XRFrame.js
+++ b/src/api/XRFrame.js
@@ -25,14 +25,15 @@ export default class XRFrame {
    * @param {XRSession} session
    * @param {number} sessionId
    */
-  constructor(device, session, sessionId) {
+  constructor(device, session, stereo, sessionId) {
     // Non-immersive sessions only have a monoscopic view.
-    const views = [
-      new XRView(device, 'left', sessionId),
-    ];
+    const views = [];
 
-    if (session.immersive) {
-      views.push(new XRView(device, 'right', sessionId));
+    if (stereo) {
+      views.push(new XRView(device, 'left', sessionId),
+                 new XRView(device, 'right', sessionId));
+    } else {
+      views.push(new XRView(device, 'none', sessionId));
     }
 
     this[PRIVATE] = {

--- a/src/api/XRView.js
+++ b/src/api/XRView.js
@@ -18,7 +18,7 @@ import * as mat4 from 'gl-matrix/src/gl-matrix/mat4';
 import XRViewport from './XRViewport';
 import XRRigidTransform from './XRRigidTransform';
 
-const XREyes = ['left', 'right'];
+const XREyes = ['left', 'right', 'none'];
 
 export const PRIVATE = Symbol('@@webxr-polyfill/XRView');
 

--- a/src/api/XRViewerPose.js
+++ b/src/api/XRViewerPose.js
@@ -93,7 +93,7 @@ export default class XRViewerPose extends XRPose {
     }
 
     for (let view of this[PRIVATE].views) {
-      if (view.eye == "left") {
+      if (view.eye == "left" || view.eye == "none") {
         view._updateViewMatrix(this[PRIVATE].leftViewMatrix);
       } else if (view.eye == "right") {
         view._updateViewMatrix(this[PRIVATE].rightViewMatrix);

--- a/src/devices/XRDevice.js
+++ b/src/devices/XRDevice.js
@@ -37,40 +37,12 @@ export default class XRDevice extends EventTarget {
   }
 
   /**
-   * @return {number}
-   */
-  get depthNear() { throw new Error('Not implemented'); }
-
-  /**
-   * @param {number}
-   */
-  set depthNear(val) { throw new Error('Not implemented'); }
-
-  /**
-   * @return {number}
-   */
-  get depthFar() { throw new Error('Not implemented'); }
-
-  /**
-   * @param {number}
-   */
-  set depthFar(val) { throw new Error('Not implemented'); }
-
-  /**
    * Called when a XRSession has a `baseLayer` property set.
    *
    * @param {number} sessionId
    * @param {XRWebGLLayer} layer
    */
   onBaseLayerSet(sessionId, layer) { throw new Error('Not implemented'); }
-
-  /**
-   * Called when a XRSession has an `inlineVerticalFieldOfView` property set.
-   *
-   * @param {number} sessionId
-   * @param {float} value
-   */
-  onInlineVerticalFieldOfViewSet(sessionId, value) { throw new Error('Not implemented'); }
 
   /**
    * @param {XRSessionMode} mode


### PR DESCRIPTION
While working on a different fix, I noticed several issues that are fixed here:

 - `XRSession` should not have an `immmersive`, `outputContext`, `depthNear`, `depthFar`, or `baseLayer` attribute.
 - `depthNear` and `depthFar` were being handled entirely wrong, and would never apply to the WebVR backend if used correctly.
 - `XRView`s were incapable of reporting an eye of `none`.

Also did a small amount of simplification work for the internal XRDevice interface.