### PR TITLE
Expose gamepad hapticActuators property if the browser supplies it

### DIFF
--- a/src/devices/GamepadXRInputSource.js
+++ b/src/devices/GamepadXRInputSource.js
@@ -145,6 +145,11 @@ class XRRemappedGamepad {
   get buttons() {
     return this[PRIVATE].buttons;
   }
+
+  // Non-standard extension
+  get hapticActuators() {
+    return this[PRIVATE].gamepad.hapticActuators;
+  }
 }
 
 export default class GamepadXRInputSource {


### PR DESCRIPTION
This is a "pretty please" to get access to hand controller haptics if the browser supports that extension.

https://w3c.github.io/gamepad/extensions.html#dom-gamepad-hapticactuators