### PR TITLE
Squeeze event support

### DIFF
--- a/src/api/XRSession.js
+++ b/src/api/XRSession.js
@@ -210,6 +210,29 @@ export default class XRSession extends EventTarget {
     };
     device.addEventListener('@@webxr-polyfill/input-select-end', this[PRIVATE].onSelectEnd);
 
+    this[PRIVATE].onSqueezeStart = evt => {
+      // Ignore if this event is not for this session.
+      if (evt.sessionId !== this[PRIVATE].id) {
+        return;
+      }
+
+      this[PRIVATE].dispatchInputSourceEvent('squeezestart',  evt.inputSource);
+    };
+    device.addEventListener('@@webxr-polyfill/input-squeeze-start', this[PRIVATE].onSqueezeStart);
+
+    this[PRIVATE].onSqueezeEnd = evt => {
+      // Ignore if this event is not for this session.
+      if (evt.sessionId !== this[PRIVATE].id) {
+        return;
+      }
+
+      this[PRIVATE].dispatchInputSourceEvent('squeezeend',  evt.inputSource);
+
+      // Following the same way as select event
+      this[PRIVATE].dispatchInputSourceEvent('squeeze',  evt.inputSource);
+    };
+    device.addEventListener('@@webxr-polyfill/input-squeeze-end', this[PRIVATE].onSqueezeEnd);
+
     this[PRIVATE].dispatchInputSourceEvent = (type, inputSource) => {
       const frame = new XRFrame(device, this, this[PRIVATE].immersive, this[PRIVATE].id);
       const event = new XRInputSourceEvent(type, { frame, inputSource });

--- a/src/devices/GamepadXRInputSource.js
+++ b/src/devices/GamepadXRInputSource.js
@@ -148,7 +148,7 @@ class XRRemappedGamepad {
 }
 
 export default class GamepadXRInputSource {
-  constructor(polyfill, display, primaryButtonIndex = 0) {
+  constructor(polyfill, display, primaryButtonIndex = 0, primarySqueezeButtonIndex = -1) {
     this.polyfill = polyfill;
     this.display = display;
     this.nativeGamepad = null;
@@ -160,6 +160,8 @@ export default class GamepadXRInputSource {
     this.outputMatrix = mat4.create();
     this.primaryButtonIndex = primaryButtonIndex;
     this.primaryActionPressed = false;
+    this.primarySqueezeButtonIndex = primarySqueezeButtonIndex;
+    this.primarySqueezeActionPressed = false;
     this.handedness = '';
     this.targetRayMode = 'gaze';
     this.armModel = null;

--- a/src/devices/WebVRDevice.js
+++ b/src/devices/WebVRDevice.js
@@ -320,6 +320,16 @@ export default class WebVRDevice extends XRDevice {
             }
             inputSourceImpl.primaryActionPressed = primaryActionPressed;
           }
+          if (inputSourceImpl.primarySqueezeButtonIndex != -1) {
+            let primarySqueezeActionPressed = gamepad.buttons[inputSourceImpl.primarySqueezeButtonIndex].pressed;
+            if (primarySqueezeActionPressed && !inputSourceImpl.primarySqueezeActionPressed) {
+              this.dispatchEvent('@@webxr-polyfill/input-squeeze-start', { sessionId: session.id, inputSource: inputSourceImpl.inputSource });
+            } else if (!primarySqueezeActionPressed && inputSourceImpl.primarySqueezeActionPressed) {
+              // This will also fire a select event
+              this.dispatchEvent('@@webxr-polyfill/input-squeeze-end', { sessionId: session.id, inputSource: inputSourceImpl.inputSource });
+            }
+            inputSourceImpl.primarySqueezeActionPressed = primarySqueezeActionPressed;
+          }
         }
       }
     }


### PR DESCRIPTION
This PR adds squeeze/squeezestart/squeezeend events defined in [WebXR API Editor's draft](https://immersive-web.github.io/webxr/)

One thing. I'm not sure how to find primary squeeze button index in WebVRDevice. Similarly to primary button index, can we detect from gamepad.id? I set it the default value -1 (no squeeze button) in WebVRDevice so far.

https://github.com/immersive-web/webxr-polyfill/blob/95a437a3ceaf30ed452f7cf0ac0e14ebb5f084f8/src/devices/WebVRDevice.js#L307