### PR TITLE
Significantly refactor how Spaces work

### DIFF
--- a/src/api/XRFrame.js
+++ b/src/api/XRFrame.js
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import {PRIVATE as SESSION_PRIVATE} from './XRSession';
 import XRViewerPose from './XRViewerPose';
 import XRView from './XRView';
 import { mat4 } from 'gl-matrix';
@@ -22,30 +23,22 @@ export const PRIVATE = Symbol('@@webxr-polyfill/XRFrame');
 const NON_ACTIVE_MSG = "XRFrame access outside the callback that produced it is invalid.";
 const NON_ANIMFRAME_MSG = "getViewerPose can only be called on XRFrame objects passed to XRSession.requestAnimationFrame callbacks.";
 
+let NEXT_FRAME_ID = 0;
+
 export default class XRFrame {
   /**
    * @param {XRDevice} device
    * @param {XRSession} session
    * @param {number} sessionId
    */
-  constructor(device, session, stereo, sessionId) {
-    // Non-immersive sessions only have a monoscopic view.
-    const views = [];
-
-    if (stereo) {
-      views.push(new XRView(device, 'left', sessionId),
-                 new XRView(device, 'right', sessionId));
-    } else {
-      views.push(new XRView(device, 'none', sessionId));
-    }
-
+  constructor(device, session, sessionId) {
     this[PRIVATE] = {
+      id: ++NEXT_FRAME_ID,
       active: false,
       animationFrame: false,
       device,
-      viewerPose: new XRViewerPose(device, views),
-      views,
       session,
+      sessionId
     };
   }
 
@@ -55,18 +48,35 @@ export default class XRFrame {
   get session() { return this[PRIVATE].session; }
 
   /**
-   * @param {XRSpace} space
+   * @param {XRReferenceSpace} referenceSpace
    * @return {XRViewerPose?}
    */
-  getViewerPose(space) {
+  getViewerPose(referenceSpace) {
     if (!this[PRIVATE].animationFrame) {
       throw new DOMException(NON_ANIMFRAME_MSG, 'InvalidStateError');
     }
     if (!this[PRIVATE].active) {
       throw new DOMException(NON_ACTIVE_MSG, 'InvalidStateError');
     }
-    this[PRIVATE].viewerPose._updateFromReferenceSpace(space);
-    return this[PRIVATE].viewerPose;
+
+    const device = this[PRIVATE].device;
+    const session = this[PRIVATE].session;
+
+    session[SESSION_PRIVATE].viewerSpace._ensurePoseUpdated(device, this[PRIVATE].id);
+    referenceSpace._ensurePoseUpdated(device, this[PRIVATE].id);
+
+    let viewerTransform = referenceSpace._getSpaceRelativeTransform(session[SESSION_PRIVATE].viewerSpace);
+
+    const views = [];
+    for (let viewSpace of session[SESSION_PRIVATE].viewSpaces) {
+      viewSpace._ensurePoseUpdated(device, this[PRIVATE].id);
+      let viewTransform = referenceSpace._getSpaceRelativeTransform(viewSpace);
+      let view = new XRView(device, viewTransform, viewSpace.eye, this[PRIVATE].sessionId);
+      views.push(view);
+    }
+    let viewerPose = new XRViewerPose(viewerTransform, views, false /* TODO: emulatedPosition */);
+
+    return viewerPose;
   }
 
   /**
@@ -78,18 +88,18 @@ export default class XRFrame {
     if (!this[PRIVATE].active) {
       throw new DOMException(NON_ACTIVE_MSG, 'InvalidStateError');
     }
-    if (space._specialType === "viewer") {
-      // Don't just return the viewer pose since the resulting pose shouldn't
-      // include the views array - it should just have the transform.
-      let viewerPose = this.getViewerPose(baseSpace);
-      return new XRPose(
-        new XRRigidTransform(viewerPose.poseModelMatrix),
-        viewerPose.emulatedPosition);
-    }
 
+    const device = this[PRIVATE].device;
     if (space._specialType === "target-ray" || space._specialType === "grip") {
-      return this[PRIVATE].device.getInputPose(
+      // TODO: Stop special-casing input.
+      return device.getInputPose(
         space._inputSource, baseSpace, space._specialType);
+    } else {
+      space._ensurePoseUpdated(device, this[PRIVATE].id);
+      baseSpace._ensurePoseUpdated(device, this[PRIVATE].id);
+      let transform = baseSpace._getSpaceRelativeTransform(space);
+      if (!transform) { return null; }
+      return new XRPose(transform, false /* TODO: emulatedPosition */);
     }
 
     return null;

--- a/src/api/XRPose.js
+++ b/src/api/XRPose.js
@@ -36,9 +36,4 @@ export default class XRPose {
    * @return {bool}
    */
   get emulatedPosition() { return this[PRIVATE].emulatedPosition; }
-
-  /**
-   * @param {XRRigidTransform} transform 
-   */
-  _setTransform(transform) { this[PRIVATE].transform = transform; }
 }

--- a/src/api/XRSpace.js
+++ b/src/api/XRSpace.js
@@ -12,6 +12,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import XRRigidTransform from './XRRigidTransform';
+import * as mat4 from 'gl-matrix/src/gl-matrix/mat4';
 
 export const PRIVATE = Symbol('@@webxr-polyfill/XRSpace');
 
@@ -30,6 +32,10 @@ export default class XRSpace {
     this[PRIVATE] = {
       specialType,
       inputSource,
+      // The transform for the space in the base space, along with it's inverse
+      baseMatrix: null,
+      inverseBaseMatrix: null,
+      lastFrameId: -1
     };
   }
 
@@ -45,5 +51,90 @@ export default class XRSpace {
    */
   get _inputSource() {
     return this[PRIVATE].inputSource;
+  }
+
+  /**
+   * NON-STANDARD
+   * Trigger an update for this space's base pose if necessary
+   * @param {XRDevice} device
+   * @param {Number} frameId
+   */
+  _ensurePoseUpdated(device, frameId) {
+    if (frameId == this[PRIVATE].lastFrameId) return;
+    this[PRIVATE].lastFrameId = frameId;
+    this._onPoseUpdate(device);
+  }
+
+  /**
+   * NON-STANDARD
+   * Called when this space's base pose needs to be updated
+   * @param {XRDevice} device
+   */
+  _onPoseUpdate(device) {
+    if (this[PRIVATE].specialType == 'viewer') {
+      this._baseMatrix = device.getBasePoseMatrix();
+    }
+  }
+
+  /**
+   * NON-STANDARD
+   * @param {Float32Array(16)} matrix
+   */
+  set _baseMatrix(matrix) {
+    this[PRIVATE].baseMatrix = matrix;
+    this[PRIVATE].inverseBaseMatrix = null;
+  }
+
+  /**
+   * NON-STANDARD
+   * @return {Float32Array(16)}
+   */
+  get _baseMatrix() {
+    if (!this[PRIVATE].baseMatrix) {
+      if (this[PRIVATE].inverseBaseMatrix) {
+        this[PRIVATE].baseMatrix = new Float32Array(16);
+        mat4.invert(this[PRIVATE].baseMatrix, this[PRIVATE].inverseBaseMatrix);
+      }
+    }
+    return this[PRIVATE].baseMatrix;
+  }
+
+  /**
+   * NON-STANDARD
+   * @param {Float32Array(16)} matrix
+   */
+  set _inverseBaseMatrix(matrix) {
+    this[PRIVATE].inverseBaseMatrix = matrix;
+    this[PRIVATE].baseMatrix = null;
+  }
+
+  /**
+   * NON-STANDARD
+   * @return {Float32Array(16)}
+   */
+  get _inverseBaseMatrix() {
+    if (!this[PRIVATE].inverseBaseMatrix) {
+      if (this[PRIVATE].baseMatrix) {
+        this[PRIVATE].inverseBaseMatrix = new Float32Array(16);
+        mat4.invert(this[PRIVATE].inverseBaseMatrix, this[PRIVATE].baseMatrix);
+      }
+    }
+    return this[PRIVATE].inverseBaseMatrix;
+  }
+
+  /**
+   * NON-STANDARD
+   * Gets the transform of the given space in this space
+   *
+   * @param {XRSpace} space
+   * @return {XRRigidTransform}
+   */
+  _getSpaceRelativeTransform(space) {
+    if (!this._inverseBaseMatrix || !space._baseMatrix) {
+      return null;
+    }
+    let out = new Float32Array(16);
+    mat4.multiply(out, this._inverseBaseMatrix, space._baseMatrix);
+    return new XRRigidTransform(out);
   }
 }

--- a/src/api/XRView.js
+++ b/src/api/XRView.js
@@ -28,7 +28,7 @@ export default class XRView {
    * @param {XREye} eye
    * @param {number} sessionId
    */
-  constructor(device, eye, sessionId) {
+  constructor(device, transform, eye, sessionId) {
     if (!XREyes.includes(eye)) {
       throw new Error(`XREye must be one of: ${XREyes}`);
     }
@@ -45,7 +45,7 @@ export default class XRView {
       viewport,
       temp,
       sessionId,
-      transform: null,
+      transform,
     };
   }
 
@@ -63,15 +63,6 @@ export default class XRView {
    * @return {XRRigidTransform}
    */
   get transform() { return this[PRIVATE].transform; }
-
-  /**
-   * @param {mat4} viewMatrix 
-   */
-  _updateViewMatrix(viewMatrix) {
-    let invMatrix = mat4.identity(new Float32Array(16));
-    mat4.invert(invMatrix, viewMatrix);
-    this[PRIVATE].transform = new XRRigidTransform(invMatrix);
-  }
 
   /**
    * NON-STANDARD


### PR DESCRIPTION
Fixes an issue that appeared when trying to compose view transforms from
multiple poses. (See [this sample](https://immersive-web.github.io/webxr-samples/tests/composed-views.html) for a demonstration of the issue.) This was
primarily caused by re-using the same viewerPose object for each pose.
The entire system was built on fragile special cases, though, and it was badly
in need of a more general approach.

Input spaces are still a special case but don't really need to be
anymore. I just don't want to make this PR any bigger.

