### PR TITLE
Fixed an issue with offset reference spaces

### DIFF
--- a/src/api/XRFrame.js
+++ b/src/api/XRFrame.js
@@ -16,7 +16,6 @@
 import {PRIVATE as SESSION_PRIVATE} from './XRSession';
 import XRViewerPose from './XRViewerPose';
 import XRView from './XRView';
-import { mat4 } from 'gl-matrix';
 
 export const PRIVATE = Symbol('@@webxr-polyfill/XRFrame');
 

--- a/src/api/XRReferenceSpace.js
+++ b/src/api/XRReferenceSpace.js
@@ -72,23 +72,9 @@ export default class XRReferenceSpace extends XRSpace {
 
     this[PRIVATE] = {
       type,
+      transform,
       originOffset : mat4.identity(new Float32Array(16)),
     };
-  }
-
-  /**
-   * NON-STANDARD
-   * Called when this space's base pose needs to be updated
-   * @param {XRDevice} device
-   */
-  _onPoseUpdate(device) {
-    switch(this[PRIVATE].type) {
-      case 'viewer': 
-        this._baseMatrix = device.getBasePoseMatrix();
-        break;
-      default:
-        break;
-    }
   }
 
   /**


### PR DESCRIPTION
Turns out we weren't properly passing along the base transform to the new reference space, which would cause it to appear off in cases like `local-floor` or `bounded-floor` reference spaces on devices with real floor detection. (Devices that fell back to the emulated height for `local-floor` did OK.)

FYI: This fix has already been applied to the WebXR samples, so you can validate that it works with any given device by visiting https://immersive-web.github.io/webxr-samples/tests/ref-space-invert.html