### PR TITLE
Add support for XRWebGLLayer.getNativeFramebufferScaleFactor()

### DIFF
--- a/src/WebXRPolyfill.js
+++ b/src/WebXRPolyfill.js
@@ -146,29 +146,5 @@ export default class WebXRPolyfill {
         return originalSupportsSession.call(this, mode);
       }
     }
-
-    // Patch for Chrome 76-77: Requires that inline XRWebGLLayers be created
-    // with { compositionDisabled: true }, so intercept the layer constructor
-    // and force it to always set that based on the session mode.
-    if (global.XRWebGLLayer) {
-      let originalRequestSession = global.navigator.xr.requestSession;
-      global.navigator.xr.requestSession = function(mode, options) {
-        return originalRequestSession.call(this, mode, options).then((session) => {
-          session._session_mode = mode;
-          return session;
-        });
-      }
-
-      var originalXRLayer = global.XRWebGLLayer;
-      global.XRWebGLLayer = function(session, gl, options) {
-        if (!options) {
-          options = {};
-        }
-
-        options.compositionDisabled = (session._session_mode === "inline");
-
-        return new originalXRLayer(session, gl, options);
-      }
-    }
   }
 }

--- a/src/api/XRWebGLLayer.js
+++ b/src/api/XRWebGLLayer.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import XRSession from './XRSession';
+import XRSession, { PRIVATE as SESSION_PRIVATE } from './XRSession';
 import {
   POLYFILLED_XR_COMPATIBLE,
   XR_COMPATIBLE,
@@ -116,5 +116,23 @@ export default class XRWebGLLayer {
    */
   getViewport(view) {
     return view._getViewport(this);
+  }
+
+  /**
+   * Gets the scale factor to be requested if you want to match the device
+   * resolution at the center of the user's vision. The polyfill will always
+   * report 1.0.
+   * 
+   * @param {XRSession} session 
+   * @return {number}
+   */
+  static getNativeFramebufferScaleFactor(session) {
+    if (!session) {
+      throw new TypeError('getNativeFramebufferScaleFactor must be passed a session.')
+    }
+
+    if (session[SESSION_PRIVATE].ended) { return 0.0; }
+
+    return 1.0;
   }
 }


### PR DESCRIPTION
Turns out that the method wasn't added to the polyfill's definition of `XRWebGLLayer` _and_ the polyfill was also breaking native implementations by shimming the `XRWebGLLayer` constructor to account for Chrome 76/77 compatibility issues (now no longer available).