### PR TITLE
Fix event names in XRSession

### DIFF
--- a/src/api/XRSession.js
+++ b/src/api/XRSession.js
@@ -199,10 +199,10 @@ export default class XRSession extends EventTarget {
       // in this XRSession
       this[PRIVATE].ended = true;
       this[PRIVATE].stopDeviceFrameLoop();
-      device.removeEventListener('@webvr-polyfill/vr-present-end', this[PRIVATE].onPresentationEnd);
-      device.removeEventListener('@webvr-polyfill/vr-present-start', this[PRIVATE].onPresentationStart);
-      device.removeEventListener('@@webvr-polyfill/input-select-start', this[PRIVATE].onSelectStart);
-      device.removeEventListener('@@webvr-polyfill/input-select-end', this[PRIVATE].onSelectEnd);
+      device.removeEventListener('@@webxr-polyfill/vr-present-end', this[PRIVATE].onPresentationEnd);
+      device.removeEventListener('@@webxr-polyfill/vr-present-start', this[PRIVATE].onPresentationStart);
+      device.removeEventListener('@@webxr-polyfill/input-select-start', this[PRIVATE].onSelectStart);
+      device.removeEventListener('@@webxr-polyfill/input-select-end', this[PRIVATE].onSelectEnd);
       this.dispatchEvent('end', new XRSessionEvent('end', { session: this }));
     };
     device.addEventListener('@@webxr-polyfill/vr-present-end', this[PRIVATE].onPresentationEnd);
@@ -409,13 +409,13 @@ export default class XRSession extends EventTarget {
     // will call the `onPresentationEnd` handler, wrapping this up.
     if (this[PRIVATE].immersive) {
       this[PRIVATE].ended = true;
-      this[PRIVATE].device.removeEventListener('@@webvr-polyfill/vr-present-start',
+      this[PRIVATE].device.removeEventListener('@@webxr-polyfill/vr-present-start',
                                                  this[PRIVATE].onPresentationStart);
-      this[PRIVATE].device.removeEventListener('@@webvr-polyfill/vr-present-end',
+      this[PRIVATE].device.removeEventListener('@@webxr-polyfill/vr-present-end',
                                                  this[PRIVATE].onPresentationEnd);
-      this[PRIVATE].device.removeEventListener('@@webvr-polyfill/input-select-start',
+      this[PRIVATE].device.removeEventListener('@@webxr-polyfill/input-select-start',
                                                  this[PRIVATE].onSelectStart);
-      this[PRIVATE].device.removeEventListener('@@webvr-polyfill/input-select-end',
+      this[PRIVATE].device.removeEventListener('@@webxr-polyfill/input-select-end',
                                                  this[PRIVATE].onSelectEnd);
 
       this.dispatchEvent('end', new XRSessionEvent('end', { session: this }));


### PR DESCRIPTION
If I'm right, `XRSession` uses event name `@webvr-polyfill/*` and `@@webvr-polyfill/*` at some places but I think they are typos because `@webvr-polyfill/*` or `@@webvr-polyfill/*` aren't used everywhere else but `@@webxr-polyfill/*` is used.

Even in the same `XRSession` [here](https://github.com/immersive-web/webxr-polyfill/blob/master/src/api/XRSession.js#L208) uses `@@webxr-polyfill/*` to register a listener but [here](https://github.com/immersive-web/webxr-polyfill/blob/master/src/api/XRSession.js#L202) uses `@webvr-polyfill/*` to remove the listener. The listener won't be removed because they use different names.

This PR fixes this problem by renaming `@webvr-polyfill/*` or `@@webvr-polyfill/*` to `@@webxr-polyfill/*`.