### PR TITLE
select event immediately before selectend event

### DIFF
--- a/src/api/XRSession.js
+++ b/src/api/XRSession.js
@@ -234,10 +234,10 @@ export default class XRSession extends EventTarget {
         return;
       }
 
-      this[PRIVATE].dispatchInputSourceEvent('selectend',  evt.inputSource);
-
       // Sadly, there's no way to make this a user gesture.
       this[PRIVATE].dispatchInputSourceEvent('select',  evt.inputSource);
+      
+      this[PRIVATE].dispatchInputSourceEvent('selectend',  evt.inputSource);
     };
     device.addEventListener('@@webxr-polyfill/input-select-end', this[PRIVATE].onSelectEnd);
 


### PR DESCRIPTION
As written in the working draft https://www.w3.org/TR/webxr/#xrinputsource-interface
```
Queue a task to perform the following steps:
Fire an input source event with name select, frame frame, and source source.
Fire an input source event with name selectend, frame frame, and source source
```

And in https://developer.mozilla.org/en-US/docs/Web/API/XRSession
```
The select event is sent after the selectstart event is sent and immediately before the selectend event is sent.
```