### PR TITLE
cleanup TravisCI related stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-  - "8"
-
-cache:
-  directories:
-    - node_modules

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # WebXR Polyfill
 
-[![Build Status](http://img.shields.io/travis/immersive-web/webxr-polyfill.svg?style=flat-square)](https://travis-ci.org/immersive-web/webxr-polyfill)
 [![Build Status](http://img.shields.io/npm/v/webxr-polyfill.svg?style=flat-square)](https://www.npmjs.org/package/webxr-polyfill)
 
 A JavaScript implementation of the [WebXR Device API][webxr-spec], as well as the [WebXR Gamepad Module][webxr-gamepad-module]. This polyfill allows developers to write against the latest specification, providing support when run on browsers that implement the [WebVR 1.1 spec][webvr-spec], or on mobile devices with no WebVR/WebXR support at all.


### PR DESCRIPTION
- removed badge on README
- removed .travis.yml

Question, there is both [LICENSE](https://github.com/immersive-web/webxr-polyfill/blob/main/LICENSE) as Apache 2.0 and [licenses.txt](https://github.com/immersive-web/webxr-polyfill/blob/main/licenses.txt) as original Google one. [License section in README](https://github.com/immersive-web/webxr-polyfill/blob/main/LICENSE) states Apache 2.0, should we remove licenses.txt?